### PR TITLE
Reduced Schedule

### DIFF
--- a/.github/workflows/update-environment-variables.yml
+++ b/.github/workflows/update-environment-variables.yml
@@ -1,7 +1,7 @@
 name: Update environment-variables
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-executable-jar.yml
+++ b/.github/workflows/update-executable-jar.yml
@@ -1,7 +1,7 @@
 name: Update executable-jar
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-graalvm.yml
+++ b/.github/workflows/update-graalvm.yml
@@ -1,7 +1,7 @@
 name: Update graalvm
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-gradle.yml
+++ b/.github/workflows/update-gradle.yml
@@ -1,7 +1,7 @@
 name: Update gradle
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-image-labels.yml
+++ b/.github/workflows/update-image-labels.yml
@@ -1,7 +1,7 @@
 name: Update image-labels
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-leiningen.yml
+++ b/.github/workflows/update-leiningen.yml
@@ -1,7 +1,7 @@
 name: Update leiningen
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-maven.yml
+++ b/.github/workflows/update-maven.yml
@@ -1,7 +1,7 @@
 name: Update maven
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-procfile.yml
+++ b/.github/workflows/update-procfile.yml
@@ -1,7 +1,7 @@
 name: Update procfile
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-sbt.yml
+++ b/.github/workflows/update-sbt.yml
@@ -1,7 +1,7 @@
 name: Update sbt
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-spring-boot-native-image.yml
+++ b/.github/workflows/update-spring-boot-native-image.yml
@@ -1,7 +1,7 @@
 name: Update spring-boot-native-image
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-spring-boot.yml
+++ b/.github/workflows/update-spring-boot.yml
@@ -1,7 +1,7 @@
 name: Update spring-boot
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:


### PR DESCRIPTION
Previously, the regularly scheduled builds exhausted the free tier of GitHub actions in some orgs.  This change reduces the number of hours and number of days that these scheduled events will run.