### PR TITLE
Remove Dependabot Config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-    - package-ecosystem: github-actions
-      directory: /
-      schedule:
-        interval: daily
-      labels:
-        - semver:patch
-        - type:dependency-upgrade


### PR DESCRIPTION
Pipeline builder will manage updates of github actions so dependabot is no longer needed on this repo.
