### PR TITLE
Pull in renamed paketo-buildpack/native-image 4.0.0

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -33,7 +33,7 @@ group = [
 ### Order determines precedence
   { id = "paketo-buildpacks/executable-jar",           version="5.0.0", optional = true },
   { id = "paketo-buildpacks/spring-boot",              version="4.1.0", optional = true },
-  { id = "paketo-buildpacks/spring-boot-native-image", version="3.0.0" },
+  { id = "paketo-buildpacks/native-image",             version="4.0.0" },
   { id = "paketo-buildpacks/procfile",                 version="4.0.0", optional = true },
 
 ### Order is strictly enforced

--- a/package.toml
+++ b/package.toml
@@ -6,8 +6,8 @@ dependencies = [
   { uri = "docker://gcr.io/paketo-buildpacks/image-labels:3.0.0" },
   { uri = "docker://gcr.io/paketo-buildpacks/leiningen:3.0.0" },
   { uri = "docker://gcr.io/paketo-buildpacks/maven:5.0.0" },
+  { uri = "docker://gcr.io/paketo-buildpacks/native-image:4.0.0" },
   { uri = "docker://gcr.io/paketo-buildpacks/procfile:4.0.0" },
   { uri = "docker://gcr.io/paketo-buildpacks/sbt:5.0.0" },
-  { uri = "docker://gcr.io/paketo-buildpacks/spring-boot:4.1.0" },
-  { uri = "docker://gcr.io/paketo-buildpacks/spring-boot-native-image:3.0.0" },
+  { uri = "docker://gcr.io/paketo-buildpacks/spring-boot:4.1.0" }
 ]


### PR DESCRIPTION
`paketo-buildpacks/spring-boot-native-image` has been renamed to reflect the fact that it is no longer boot-specific.