### PR TITLE
Add back Paketo CA Certificates buildpack

### DIFF
--- a/.github/workflows/update-ca-certificates.yml
+++ b/.github/workflows/update-ca-certificates.yml
@@ -1,0 +1,119 @@
+name: Update ca-certificates
+"on":
+    schedule:
+        - cron: 0 12-23 * * 1-5
+    workflow_dispatch: {}
+jobs:
+    update:
+        name: Update Package Dependency
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
+              uses: docker/login-action@v1
+              with:
+                password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}
+                registry: gcr.io
+                username: _json_key
+            - uses: actions/setup-go@v2
+              with:
+                go-version: "1.15"
+            - name: Install update-package-dependency
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                GO111MODULE=on go get -u -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-package-dependency
+            - name: Install crane
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing crane ${CRANE_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --show-error \
+                  --silent \
+                  --location \
+                  "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
+                | tar -C "${HOME}/bin" -xz crane
+              env:
+                CRANE_VERSION: 0.1.4
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v2
+            - id: package
+              name: Update Package Dependency
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
+
+                if [[ -e builder.toml ]]; then
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].uri | capture(\".*${DEPENDENCY}:(?<version>.+)\") | .version")
+
+                  update-package-dependency \
+                    --builder-toml builder.toml \
+                    --id "${DEPENDENCY}" \
+                    --version "${NEW_VERSION}"
+
+                  git add builder.toml
+                elif [[ -e package.toml ]]; then
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].uri | capture(\".*${DEPENDENCY}:(?<version>.+)\") | .version")
+
+                  update-package-dependency \
+                    --buildpack-toml buildpack.toml \
+                    --package-toml package.toml \
+                    --id "${DEPENDENCY}" \
+                    --version "${NEW_VERSION}"
+
+                  git add buildpack.toml package.toml
+                fi
+
+                git checkout -- .
+
+                echo "::set-output name=old-version::${OLD_VERSION}"
+                echo "::set-output name=new-version::${NEW_VERSION}"
+              env:
+                DEPENDENCY: gcr.io/paketo-buildpacks/ca-certificates
+            - uses: peter-evans/create-pull-request@v3
+              with:
+                author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
+                body: Bumps [`gcr.io/paketo-buildpacks/ca-certificates`](https://gcr.io/paketo-buildpacks/ca-certificates) from [`${{ steps.package.outputs.old-version }}`](https://gcr.io/paketo-buildpacks/ca-certificates:${{ steps.package.outputs.old-version }}) to [`${{ steps.package.outputs.new-version }}`](https://gcr.io/paketo-buildpacks/ca-certificates:${{ steps.package.outputs.new-version }}).
+                branch: update/package/ca-certificates
+                commit-message: |-
+                    Bump gcr.io/paketo-buildpacks/ca-certificates from ${{ steps.package.outputs.old-version }} to ${{ steps.package.outputs.new-version }}
+
+                    Bumps gcr.io/paketo-buildpacks/ca-certificates from ${{ steps.package.outputs.old-version }} to ${{ steps.package.outputs.new-version }}.
+                delete-branch: true
+                labels: semver:minor, type:dependency-upgrade
+                signoff: true
+                title: Bump gcr.io/paketo-buildpacks/ca-certificates from ${{ steps.package.outputs.old-version }} to ${{ steps.package.outputs.new-version }}
+                token: ${{ secrets.JAVA_GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 The Paketo Java Native Image Buildpack is a Cloud Native Buildpack with an order definition suitable for Java native image applications.
 
 ## Included Buildpacks
+* [`paketo-buildpacks/ca-certificates`](https://github.com/paketo-buildpacks/ca-certificates)
 * [`paketo-buildpacks/environment-variables`](https://github.com/paketo-buildpacks/environment-variables)
 * [`paketo-buildpacks/executable-jar`](https://github.com/paketo-buildpacks/executable-jar)
 * [`paketo-buildpacks/graalvm`](https://github.com/paketo-buildpacks/graalvm)

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -24,6 +24,7 @@ homepage = "https://github.com/paketo-buildpacks/java-native-image"
 group = [
 
 ### Order is strictly enforced
+  { id = "paketo-buildpacks/ca-certificates",          version="2.1.0", optional = true },
   { id = "paketo-buildpacks/graalvm",                  version="6.0.0" },
   { id = "paketo-buildpacks/gradle",                   version="5.0.0", optional = true },
   { id = "paketo-buildpacks/leiningen",                version="3.0.0", optional = true },

--- a/package.toml
+++ b/package.toml
@@ -1,4 +1,5 @@
 dependencies = [
+  { uri = "docker://gcr.io/paketo-buildpacks/ca-certificates:2.1.0" },
   { uri = "docker://gcr.io/paketo-buildpacks/environment-variables:3.0.0" },
   { uri = "docker://gcr.io/paketo-buildpacks/executable-jar:5.0.0" },
   { uri = "docker://gcr.io/paketo-buildpacks/graalvm:6.0.0" },


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

fixes https://github.com/paketo-buildpacks/java-native-image/issues/96

## Summary
<!-- A short explanation of the proposed change -->
The CA Certificates buildpack was removed from the Java Native Image buildpack in v4.1.0. Recent version of the CNB lifecycle support buildpack API 0.5 and higher, so we can restore it.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
