### PR TITLE
Fixes buildpack order 

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -24,8 +24,8 @@ homepage = "https://github.com/paketo-buildpacks/java-native-image"
 group = [
 
 ### Order is strictly enforced
-  { id = "paketo-buildpacks/graalvm",                  version="6.1.0" },
   { id = "paketo-buildpacks/ca-certificates",          version="2.2.0", optional = true },
+  { id = "paketo-buildpacks/graalvm",                  version="6.1.0" },
   { id = "paketo-buildpacks/gradle",                   version="5.1.0", optional = true },
   { id = "paketo-buildpacks/leiningen",                version="3.1.0", optional = true },
   { id = "paketo-buildpacks/maven",                    version="5.1.0", optional = true },


### PR DESCRIPTION

## Summary
Order was accidentally switched when merging conflicts while bumping versions. This restores the order which should have ca-certificates first.

## Use Cases
Correct bug in order.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
