### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # `gcr.io/paketo-buildpacks/java-native-image`
-The Paketo Java Native Image Buildpack is a Cloud Native Buildpack with an order definition suitable for Java native image applications.
+The Paketo Buildpack for Java Native Image is a Cloud Native Buildpack with an order definition suitable for Java native image applications.
 
 ## Included Buildpacks
 * [`paketo-buildpacks/ca-certificates`](https://github.com/paketo-buildpacks/ca-certificates)

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://paketo.io/docs/howto/java/#build-an-app-as-a-graalvm-native-image-application"
   id = "paketo-buildpacks/java-native-image"
   keywords = ["java", "composite", "native-image"]
-  name = "Paketo Java Native Image Buildpack"
+  name = "Paketo Buildpack for Java Native Image"
   version = "{{.version}}"
 
   [[buildpack.licenses]]


### PR DESCRIPTION
Renames 'Paketo Java Native Image Buildpack' to 'Paketo Buildpack for Java Native Image'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
