### PR TITLE
Revert Maven buildpack version due to bug

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -63,7 +63,7 @@ api = "0.7"
   [[order.group]]
     id = "paketo-buildpacks/maven"
     optional = true
-    version = "6.9.0"
+    version = "6.8.0"
 
   [[order.group]]
     id = "paketo-buildpacks/sbt"

--- a/package.toml
+++ b/package.toml
@@ -18,7 +18,7 @@
   uri = "docker://gcr.io/paketo-buildpacks/gradle:6.8.0"
 
 [[dependencies]]
-  uri = "docker://gcr.io/paketo-buildpacks/maven:6.9.0"
+  uri = "docker://gcr.io/paketo-buildpacks/maven:6.8.0"
 
 [[dependencies]]
   uri = "docker://gcr.io/paketo-buildpacks/sbt:6.8.0"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This reverts the Maven buildpack version, as a [bug](https://github.com/paketo-buildpacks/maven/pull/185) has been discovered when building with compiled assets

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
